### PR TITLE
기능: 폴리모픽 컴포넌트 생성 유틸 추가

### DIFF
--- a/src/utils/types/elementTypeUtils.ts
+++ b/src/utils/types/elementTypeUtils.ts
@@ -1,0 +1,8 @@
+import type { DetailedHTMLProps, ElementType, HTMLAttributes } from 'react';
+
+/** ElementType를 HTMLElement 타입으로 변환 */
+export type ElementTypeToHTMLElement<T extends ElementType> = T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T] extends DetailedHTMLProps<HTMLAttributes<infer E>, any>
+    ? E
+    : never
+  : never;

--- a/src/utils/types/polymorphicTypes.ts
+++ b/src/utils/types/polymorphicTypes.ts
@@ -1,0 +1,29 @@
+import type {
+  ComponentPropsWithoutRef,
+  ElementType,
+  ForwardedRef,
+  PropsWithChildren,
+  PropsWithoutRef,
+  ReactElement
+} from 'react';
+import type { ElementTypeToHTMLElement } from './elementTypeUtils';
+
+/** `as` prop을 추가한 타입 */
+type withAsProp<T> = { as?: T };
+
+/** 다형성 컴포넌트의 props 타입 */
+type PolymorphicComponentProps<T extends ElementType, P = {}> = PropsWithChildren<P & withAsProp<T>> &
+  Omit<ComponentPropsWithoutRef<T>, keyof (P & withAsProp<T>)>;
+
+/** 다형성 컴포넌트 렌더링 함수 */
+export type PolymorphicRenderFunction<T extends ElementType, P = {}> = (
+  props: PropsWithoutRef<PolymorphicComponentProps<T, P>>,
+  ref: ForwardedRef<ElementTypeToHTMLElement<T>>
+) => ReactElement | null;
+
+/** 다형성 컴포넌트 타입 */
+export type PolymorphicComponent<T extends ElementType, P> = <Element extends ElementType = T>(
+  props: PolymorphicComponentProps<Element, P> & {
+    ref?: ForwardedRef<ElementTypeToHTMLElement<Element>>;
+  }
+) => ReactElement;

--- a/src/utils/createPolymorphicComponent.ts
+++ b/src/utils/createPolymorphicComponent.ts
@@ -1,0 +1,17 @@
+import { forwardRef, ElementType } from 'react';
+import { PolymorphicComponent, PolymorphicRenderFunction } from './\btypes/polymorphicTypes';
+
+/**
+ * 다형성 컴포넌트를 생성하는 함수
+ * @param render 렌더링 함수
+ * @param displayName 컴포넌트 이름
+ * @returns 생성된 다형성 컴포넌트
+ */
+export const createPolymorphicComponent = <T extends ElementType = 'div', P = {}>(
+  render: PolymorphicRenderFunction<T, P>,
+  displayName?: string
+) => {
+  const Component = forwardRef(render);
+  Component.displayName = displayName || 'PolymorphicComponent';
+  return Component as unknown as PolymorphicComponent<T, P>;
+};


### PR DESCRIPTION
## 📄 작업 내용
- 다양한 `ElementType`을 지원하는 폴리모픽 컴포넌트 생성 함수 구현
- `as` prop을 활용한 동적 태그 지원
- `forwardRef`를 사용해 `ref` 타입 안정성 확보
- 재사용성을 고려한 유틸리티 함수로 구현

---

## 🤔 추가 설명
### 구현된 주요 기능
1. `createPolymorphicComponent` 함수
   - 제네릭 타입을 사용하여 다양한 컴포넌트와 함께 사용 가능.
   - `displayName` 옵션을 통해 디버깅 용이성 확보.

2. 주요 타입 정의
   - `ElementTypeToHTMLElement`: 특정 `ElementType`에 해당하는 HTML 요소 타입 반환.
   - `PolymorphicComponentProps`: 컴포넌트 props 타입을 동적으로 처리.

---

## ✅ 체크리스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 타입 안정성 확인
- [ ] 주요 컴포넌트와 통합 테스트 완료
- [ ] `README.md` 또는 주석으로 코드 설명 추가

---